### PR TITLE
Use Express server with conditional HTTPS redirect and dev start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,18 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('No tests specified')\""
+    "test": "node -e \"console.log('No tests specified')\"",
+    "start:dev": "cross-env NODE_ENV=development node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-sslify": "^1.2.0"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,6 @@
-const http = require('http');
-const fs = require('fs');
+const express = require('express');
 const path = require('path');
-const url = require('url');
-const querystring = require('querystring');
+const fs = require('fs');
 
 const DATA_FILE = path.join(__dirname, 'data', 'pain_points.json');
 
@@ -72,52 +70,51 @@ function renderAdminPage(content) {
 </html>`;
 }
 
-const server = http.createServer((req, res) => {
-  const parsedUrl = url.parse(req.url, true);
+const app = express();
+app.use(express.urlencoded({ extended: true }));
 
-  if (req.method === 'GET' && (parsedUrl.pathname === '/' || parsedUrl.pathname === '/pain-points')) {
-    const content = readPainPoints();
-    const html = renderPainPointsPage(content);
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(html);
-  } else if (req.method === 'GET' && parsedUrl.pathname === '/admin') {
-    const content = readPainPoints();
-    const html = renderAdminPage(content);
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(html);
-  } else if (req.method === 'POST' && parsedUrl.pathname === '/admin') {
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk;
-    });
-    req.on('end', () => {
-      const parsed = querystring.parse(body);
-      const updated = {
-        sustainability: parsed.sustainability ? parsed.sustainability.split(/\r?\n/).filter(Boolean) : [],
-        integrations: parsed.integrations ? parsed.integrations.split(/\r?\n/).filter(Boolean) : []
-      };
-      writePainPoints(updated);
-      res.writeHead(302, { Location: '/pain-points' });
-      res.end();
-    });
-  } else if (req.method === 'GET' && parsedUrl.pathname === '/style.css') {
-    const cssPath = path.join(__dirname, 'public', 'style.css');
-    fs.readFile(cssPath, (err, data) => {
-      if (err) {
-        res.writeHead(404);
-        res.end('Not found');
-      } else {
-        res.writeHead(200, { 'Content-Type': 'text/css' });
-        res.end(data);
-      }
-    });
-  } else {
-    res.writeHead(404);
-    res.end('Not found');
-  }
+if (process.env.NODE_ENV === 'production') {
+  app.enable('trust proxy');
+  const enforce = require('express-sslify');
+  app.use(enforce.HTTPS({ trustProtoHeader: true }));
+}
+
+app.get(['/', '/pain-points'], (req, res) => {
+  const content = readPainPoints();
+  const html = renderPainPointsPage(content);
+  res.send(html);
+});
+
+app.get('/admin', (req, res) => {
+  const content = readPainPoints();
+  const html = renderAdminPage(content);
+  res.send(html);
+});
+
+app.post('/admin', (req, res) => {
+  const updated = {
+    sustainability: req.body.sustainability ? req.body.sustainability.split(/\r?\n/).filter(Boolean) : [],
+    integrations: req.body.integrations ? req.body.integrations.split(/\r?\n/).filter(Boolean) : []
+  };
+  writePainPoints(updated);
+  res.redirect('/pain-points');
+});
+
+app.get('/style.css', (req, res) => {
+  const cssPath = path.join(__dirname, 'public', 'style.css');
+  fs.readFile(cssPath, (err, data) => {
+    if (err) {
+      res.status(404).send('Not found');
+    } else {
+      res.type('text/css').send(data);
+    }
+  });
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
+const HOST = '0.0.0.0';
+
+app.listen(PORT, HOST, () => {
   console.log(`Server running on http://localhost:${PORT}`);
 });
+


### PR DESCRIPTION
## Summary
- replace custom HTTP server with Express
- redirect to HTTPS only in production and trust proxy
- add `start:dev` script and cross-env dependency

## Testing
- `npm test`
- ⚠️ `npm install express express-sslify` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_b_689c9295dffc832f9344e30b8c435699